### PR TITLE
Fix the gameServerGroupName for Helm install

### DIFF
--- a/Agones_EKS_FleetIQ_Integration_Package[BETA]/quick_install/fleet_eks_agones_quickinstall.sh
+++ b/Agones_EKS_FleetIQ_Integration_Package[BETA]/quick_install/fleet_eks_agones_quickinstall.sh
@@ -600,7 +600,7 @@ helm chart export ${DAEMONSETREGISTRYURL}/${DAEMONSETREGISTRYNAME}:${DAEMONSETRE
 helm chart export ${COMMONREGISTRYURL}/${COMMONREGISTRYNAME}:${COMMONREGISTRYVERSION}
 
 helm install --set aws.region=${AWS_REGION} gamelift-common-services ./gamelift-common-services/
-helm install --set aws.region=${AWS_REGION} --set gameliftDaemon.serviceAccount=${GAMELIFTDAEMONSERVICEACCOUNTNAME} --set gameServerGroupName=${GSGNAME} gamelift-daemonset ./gamelift-daemonset/
+helm install --set aws.region=${AWS_REGION} --set gameliftDaemon.serviceAccount=${GAMELIFTDAEMONSERVICEACCOUNTNAME} --set gameliftDaemon.gameServerGroupName=${GSGNAME} gamelift-daemonset ./gamelift-daemonset/
 
 
 echo "Part 3 complete."


### PR DESCRIPTION
Overwrite default the Game Server Group name using `gameliftDaemon.gameServerGroupName` instead of just `gameServerGroupName`.

This change lets the quick install script to correctly set the Game Server Group name for the DaemonSet. Else it would use the default values of "agones-game-servers" from https://github.com/awslabs/fleetiq-adapter-for-agones/blob/master/gamelift-daemon/helm-chart/values.yaml#L16 causing the DaemonSet to go into crashloop if some other Group name was used..


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
